### PR TITLE
[REFACTOR] [CONFIG] [DOCKER] docker-compose calls replaced by new "do…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ BRUTEFORCE :=$(shell echo '${BRUTEFORCE}'| tr '[:lower:]' '[:upper:]'| tr -d '[:
 
 # DOCKER
 BUILDKIT_PROGRESS=plain
+DOCKER_COMPOSE=docker compose
 
 .MAIN: test
 .PHONY: all clean dependencies help list test


### PR DESCRIPTION
…cker compose".

- Command not found: docker-compose after docker 4.32.0 update: https://stackoverflow.com/a/78788716/6366150