### PR TITLE
[BUGFIX] sonarcloud: Use 'Assert.AreSequenceEqual' instead of 'Collec…

### DIFF
--- a/src/algorithm_exercises_csharp_test/hackerrank/interview_preparation_kit/arrays/ArraysLeftRotation.Test.cs
+++ b/src/algorithm_exercises_csharp_test/hackerrank/interview_preparation_kit/arrays/ArraysLeftRotation.Test.cs
@@ -31,7 +31,7 @@ public class ArraysLeftRotationTest
     foreach (ArraysLeftRotationsTestCase test in testCases)
     {
       result = ArraysLeftRotation.rotLeft(test.Input, test.D_rotations);
-      CollectionAssert.AreEquivalent(test.Expected, result);
+      Assert.AreSequenceEqual(test.Expected, result);
     }
   }
 }

--- a/src/algorithm_exercises_csharp_test/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/FrequencyQueries.Test.cs
+++ b/src/algorithm_exercises_csharp_test/hackerrank/interview_preparation_kit/dictionaries_and_hashmaps/FrequencyQueries.Test.cs
@@ -59,7 +59,7 @@ public class FrequencyQueriesTest
     foreach (FrequencyQueriesTestCase test in testCases)
     {
       solutionFound = FrequencyQueries.freqQuery(test.Input);
-      CollectionAssert.AreEqual(
+      Assert.AreSequenceEqual(
         test.Expected,
         solutionFound,
         $"FrequencyQueries.freqQuery({test.Input}) answer must be: {test.Expected}"
@@ -75,7 +75,7 @@ public class FrequencyQueriesTest
     foreach (FrequencyQueriesTestCase test in testCase6)
     {
       solutionFound = FrequencyQueries.freqQuery(test.Input);
-      CollectionAssert.AreEqual(
+      Assert.AreSequenceEqual(
         test.Expected,
         solutionFound,
         $"FrequencyQueries.freqQuery({test.Input}) answer must be: {test.Expected}"
@@ -91,7 +91,7 @@ public class FrequencyQueriesTest
     foreach (FrequencyQueriesTestCase test in testCaseBorderCases)
     {
       solutionFound = FrequencyQueries.freqQuery(test.Input);
-      CollectionAssert.AreEqual(
+      Assert.AreSequenceEqual(
         test.Expected,
         solutionFound,
         $"FrequencyQueries.freqQuery({test.Input}) answer must be: {test.Expected}"


### PR DESCRIPTION
…tionAssert.AreEquivalent'

roslyn:MSTEST0068 roslyn