### PR TITLE
[BUGFIX] sonarcloud: Use 'Assert.AreSequenceEqual' instead of 'Collec…

### DIFF
--- a/src/algorithm_exercises_csharp_test/hackerrank/warmup/CompareTriplets.Test.cs
+++ b/src/algorithm_exercises_csharp_test/hackerrank/warmup/CompareTriplets.Test.cs
@@ -55,7 +55,7 @@ public class CompareTripletsTest
     foreach (CompareTripletsTestCase test in testCases)
     {
       result = CompareTriplets.compareTriplets(test.A, test.B);
-      CollectionAssert.AreEquivalent(test.Expected, result);
+      Assert.AreSequenceEqual(test.Expected, result);
     }
   }
 }


### PR DESCRIPTION
…tionAssert.AreEquivalent'

roslyn:MSTEST0068 roslyn